### PR TITLE
Trap Improvement

### DIFF
--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/upgrades/BaseListener.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/upgrades/BaseListener.java
@@ -124,10 +124,8 @@ public class BaseListener implements Listener {
         } else {
             // Trigger trap
             if (!team.getActiveTraps().isEmpty()) {
-                if (!team.isBedDestroyed()) {
-                    team.getActiveTraps().get(0).trigger(team, e.getPlayer());
-                    team.getActiveTraps().remove(0);
-                }
+                team.getActiveTraps().get(0).trigger(team, e.getPlayer());
+                team.getActiveTraps().remove(0);
             }
 
             /* Manage trap */

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/upgrades/menu/MenuBaseTrap.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/upgrades/menu/MenuBaseTrap.java
@@ -285,7 +285,8 @@ public class MenuBaseTrap implements MenuContent, EnemyBaseEnterTrap, TeamUpgrad
         for (Player arenaPlayer : team.getArena().getPlayers()) {
             if (team.isMember(arenaPlayer)) continue;
             if (team.getArena().isReSpawning(arenaPlayer)) continue;
-            if (arenaPlayer.getLocation().distance(team.getBed()) <= team.getArena().getIslandRadius()) {
+            // Change the detection center for player's trap purchase to the team spawn location.
+            if (arenaPlayer.getLocation().distance(team.getSpawn()) <= team.getArena().getIslandRadius()) {
                 team.getActiveTraps().remove(0).trigger(team, arenaPlayer);
                 break;
             }


### PR DESCRIPTION
1.Unable to trigger traps after the repair bed is destroyed
2.Trap detection centered around the team's spawn location