### PR TITLE
Fix a bug in purchasing when player inventory is full

### DIFF
--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/configuration/ConfigPath.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/configuration/ConfigPath.java
@@ -236,6 +236,7 @@ public class ConfigPath {
     public static final String GENERAL_FIREBALL_DAMAGE_TEAMMATES = GENERAL_FIREBALL_DAMAGE_PATH + ".teammates";
     public static final String GENERAL_BUCKET_REMOVED_AFTER_PLACEMENT_ENABLE = ".bucket-removed-after-placement";
     public static final String GENERAL_DEATH_SPECTATOR_LOC = ".death-spectator-loc";
+    public static final String GENERAL_PURCHASE_FORBIDDEN_WHEN_INV_FULL = ".purchase-forbidden-when-inv-full";
 
     public static final String GENERAL_CONFIGURATION_PERFORMANCE_PATH = "performance-settings";
     public static final String GENERAL_CONFIGURATION_PERFORMANCE_ROTATE_GEN = GENERAL_CONFIGURATION_PERFORMANCE_PATH + ".rotate-generators";

--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/language/Messages.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/language/Messages.java
@@ -358,6 +358,7 @@ public class Messages {
     public static String SHOP_UTILITY_NPC_IRON_GOLEM_NAME = "shop-utility-iron-golem";
     public static String SHOP_INSUFFICIENT_MONEY = "shop-insuff-money";
     public static String SHOP_ALREADY_BOUGHT = "shop-already-bought";
+    public static String SHOP_INV_FULL_PURCHASE_LIMIT = "shop-inv-full-purchase-limit";
     public static final String SHOP_PATH = "shop-items-messages";
     public static final String SHOP_LORE_STATUS_CANT_AFFORD = "shop-lore-status-cant-afford";
     public static final String SHOP_LORE_STATUS_CAN_BUY = "shop-lore-status-can-buy";

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/MainConfig.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/MainConfig.java
@@ -132,6 +132,7 @@ public class MainConfig extends ConfigManager {
         yml.addDefault(ConfigPath.GENERAL_FIREBALL_DAMAGE_TEAMMATES, 0.0);
         yml.addDefault(ConfigPath.GENERAL_BUCKET_REMOVED_AFTER_PLACEMENT_ENABLE, false);
         yml.addDefault(ConfigPath.GENERAL_DEATH_SPECTATOR_LOC, "1");
+        yml.addDefault(ConfigPath.GENERAL_PURCHASE_FORBIDDEN_WHEN_INV_FULL, true);
 
         //
         yml.addDefault("database.enable", false);

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/English.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/English.java
@@ -372,6 +372,7 @@ public class English extends Language {
         yml.addDefault(Messages.SHOP_INSUFFICIENT_MONEY, "{prefix}&cYou don't have enough {currency}! Need {amount} more!");
         yml.addDefault(Messages.SHOP_NEW_PURCHASE, "{prefix}&aYou purchased &6{item}");
         yml.addDefault(Messages.SHOP_ALREADY_BOUGHT, "{prefix}&cYou've already bought that!");
+        yml.addDefault(Messages.SHOP_INV_FULL_PURCHASE_LIMIT, "&cYour inventory is full, unable to purchase.");
         yml.addDefault(Messages.SHOP_UTILITY_NPC_SILVERFISH_NAME, "{TeamColor}&l{TeamName} &r{TeamColor}Silverfish");
         yml.addDefault(Messages.SHOP_UTILITY_NPC_IRON_GOLEM_NAME, "{TeamColor}{despawn}s &8[ {TeamColor}{health}&8]");
         yml.addDefault(Messages.SHOP_SEPARATOR_NAME, "&8⇧ Categories");

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/SimplifiedChinese.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/SimplifiedChinese.java
@@ -371,6 +371,7 @@ public class SimplifiedChinese extends Language {
         yml.addDefault(Messages.SHOP_INSUFFICIENT_MONEY, "{prefix}&c你没有足够的{currency}！ 还需要 {amount} 个{currency}！");
         yml.addDefault(Messages.SHOP_NEW_PURCHASE, "{prefix}&a购买&6{item}");
         yml.addDefault(Messages.SHOP_ALREADY_BOUGHT, "{prefix}&c你已经购买过了！");
+        yml.addDefault(Messages.SHOP_INV_FULL_PURCHASE_LIMIT, "&c你的背包已满，无法购买！");
         yml.addDefault(Messages.SHOP_UTILITY_NPC_SILVERFISH_NAME, "{TeamColor}&l{TeamName} &r{TeamColor}蠹虫");
         yml.addDefault(Messages.SHOP_UTILITY_NPC_IRON_GOLEM_NAME, "{TeamColor}{despawn}秒 &8[ {TeamColor}{health}&8]");
         yml.addDefault(Messages.SHOP_SEPARATOR_NAME, "&8⇧ 分类");

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/shop/main/BuyItem.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/shop/main/BuyItem.java
@@ -38,8 +38,7 @@ import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
-import static com.andrei1058.bedwars.BedWars.nms;
-import static com.andrei1058.bedwars.BedWars.plugin;
+import static com.andrei1058.bedwars.BedWars.*;
 
 @SuppressWarnings("WeakerAccess")
 public class BuyItem implements IBuyItem {
@@ -261,8 +260,35 @@ public class BuyItem implements IBuyItem {
                 }
             }
         }
-        //
-        player.getInventory().addItem(i);
+
+        if (!config.getBoolean(ConfigPath.GENERAL_PURCHASE_FORBIDDEN_WHEN_INV_FULL))
+        {
+            int fillableAmount = 0;
+            for (ItemStack stack : player.getInventory().getContents()) {
+                if (fillableAmount >= i.getAmount()) {
+                    break;
+                }
+
+                if (stack == null) {
+                    fillableAmount += i.getMaxStackSize();
+                } else if (stack.isSimilar(i) && stack.getAmount() < stack.getMaxStackSize()) {
+                    fillableAmount += stack.getMaxStackSize() - stack.getAmount();
+                }
+            }
+
+            if (fillableAmount >= i.getAmount()) player.getInventory().addItem(i);
+            else
+            {
+                ItemStack giveItem = i.clone();
+                giveItem.setAmount(fillableAmount);
+                ItemStack dropItem = i.clone();
+                dropItem.setAmount(i.getAmount() - fillableAmount);
+                player.getInventory().addItem(giveItem);
+                arena.getWorld().dropItem(player.getLocation(), dropItem);
+            }
+        }
+        else player.getInventory().addItem(i);
+
         player.updateInventory();
     }
 

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/shop/main/CategoryContent.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/shop/main/CategoryContent.java
@@ -45,6 +45,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.andrei1058.bedwars.BedWars.config;
 import static com.andrei1058.bedwars.BedWars.nms;
 import static com.andrei1058.bedwars.api.language.Language.getMsg;
 
@@ -136,6 +137,20 @@ public class CategoryContent implements ICategoryContent {
     }
 
     public void execute(Player player, ShopCache shopCache, int slot) {
+        boolean itemAutoEquip = false;
+        for (IBuyItem item : contentTiers.get(shopCache.getContentTier(getIdentifier()) - 1).getBuyItemsList()) {
+             if (item.isAutoEquip()) itemAutoEquip = true;
+        }
+
+        if (config.getBoolean(ConfigPath.GENERAL_PURCHASE_FORBIDDEN_WHEN_INV_FULL) && !itemAutoEquip)
+        {
+            if (player.getInventory().firstEmpty() == -1)
+            {
+                player.sendMessage(getMsg(player, Messages.SHOP_INV_FULL_PURCHASE_LIMIT));
+                Sounds.playSound(ConfigPath.SOUNDS_INSUFF_MONEY, player);
+                return;
+            }
+        }
 
         IContentTier ct;
 
@@ -186,7 +201,6 @@ public class CategoryContent implements ICategoryContent {
 
         //upgrade if possible
         shopCache.upgradeCachedItem(this, slot);
-
 
         //give items
         giveItems(player, shopCache, Arena.getArenaByPlayer(player));


### PR DESCRIPTION
Bug description: When the player's inventory is full, purchasing items will reduce the currency, but the player will not receive anything
1.Added configuration item "purchase-forbidden-when-in-full", allowing players to freely switch between organizing purchases/drops of items when their inventory is full