### PR TITLE
Fix sword enchantment bug

### DIFF
--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/arena/team/ITeam.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/arena/team/ITeam.java
@@ -27,6 +27,7 @@ import com.andrei1058.bedwars.api.upgrades.EnemyBaseEnterTrap;
 import org.bukkit.Location;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
@@ -216,6 +217,8 @@ public interface ITeam {
      * @param a amplifier.
      */
     void addArmorEnchantment(Enchantment e, int a);
+
+    ItemStack handleItemEnchantment(ItemStack item);
 
     /**
      * Check if target has played in this match.

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/team/BedWarsTeam.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/team/BedWarsTeam.java
@@ -301,7 +301,7 @@ public class BedWarsTeam implements ITeam {
                     i = nms.addCustomData(i, "DEFAULT_ITEM");
 
                     if (BedWars.nms.isSword(i)) {
-                        p.getInventory().addItem(i);
+                        p.getInventory().addItem(handleItemEnchantment(i));
                         break;
                     }
                 } catch (Exception ignored) {
@@ -602,7 +602,7 @@ public class BedWarsTeam implements ITeam {
         for (Player p : getMembers()) {
             for (ItemStack i : p.getInventory().getContents()) {
                 if (i == null) continue;
-                if (nms.isSword(i)) {
+                if (nms.isSword(i) || nms.isAxe(i)) {
                     ItemMeta im = i.getItemMeta();
                     im.addEnchant(e, a, true);
                     i.setItemMeta(im);
@@ -642,6 +642,24 @@ public class BedWarsTeam implements ITeam {
                 }
             }
         }, 20L);
+    }
+
+    public ItemStack handleItemEnchantment(ItemStack item)
+    {
+        ItemMeta itemMeta = item.getItemMeta();
+
+        if (itemMeta.hasEnchants()) {
+            itemMeta.getEnchants().keySet().forEach(itemMeta::removeEnchant);
+            item.setItemMeta(itemMeta);
+        }
+
+        if (!getSwordsEnchantments().isEmpty()) {
+            getSwordsEnchantments().forEach(enchantment -> {
+                item.addEnchantment(enchantment.getEnchantment(), enchantment.getAmplifier());
+            });
+        }
+
+        return item;
     }
 
     /**

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/Interact.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/Interact.java
@@ -47,6 +47,7 @@ import org.bukkit.event.player.PlayerArmorStandManipulateEvent;
 import org.bukkit.event.player.PlayerBedEnterEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.material.Openable;
 import org.bukkit.metadata.FixedMetadataValue;
@@ -144,6 +145,10 @@ public class Interact implements Listener {
                         e.setCancelled(true);
                         return;
                     }
+
+                    InventoryHolder invHolder = (InventoryHolder) b.getState();
+                    ItemStack[] invContents = invHolder.getInventory().getContents();
+
                     //make it so only team members can open chests while team is alive, and all when is eliminated
                     ITeam owner = null;
                     int isRad = a.getConfig().getInt(ConfigPath.ARENA_ISLAND_RADIUS);
@@ -152,12 +157,32 @@ public class Interact implements Listener {
                             owner = t;
                         }
                     }
+                    boolean canOpen = true;
                     if (owner != null) {
                         if (!owner.isMember(p)) {
                             if (!(owner.getMembers().isEmpty() && owner.isBedDestroyed())) {
                                 e.setCancelled(true);
+                                canOpen = false;
                                 p.sendMessage(getMsg(p, Messages.INTERACT_CHEST_CANT_OPEN_TEAM_ELIMINATED));
                             }
+                        }
+                    }
+
+                    if (canOpen)
+                    {
+                        for (ItemStack item : invContents) {
+                            if (item != null && nms.isSword(item)) {
+                                item.setItemMeta(a.getTeam(p).handleItemEnchantment(item).getItemMeta());
+                            }
+                        }
+                    }
+                }
+                if (b.getType() == Material.ENDER_CHEST)
+                {
+                    for (ItemStack item : p.getEnderChest().getContents())
+                    {
+                        if (item != null && nms.isSword(item)) {
+                            item.setItemMeta(a.getTeam(p).handleItemEnchantment(item).getItemMeta());
                         }
                     }
                 }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/Inventory.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/Inventory.java
@@ -39,6 +39,7 @@ import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.player.PlayerPickupItemEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffectType;
 
@@ -229,5 +230,18 @@ public class Inventory implements Listener {
     public void onGameEnd(GameStateChangeEvent e) {
         if(e.getNewState() != GameState.restarting) return;
         e.getArena().getPlayers().forEach(Player::closeInventory); // close any open guis when the game ends (e.g. shop)
+    }
+
+    @EventHandler
+    public void onPickUp(PlayerPickupItemEvent event) {
+        Player player = event.getPlayer();
+        ItemStack item = event.getItem().getItemStack();
+        IArena arena = Arena.getArenaByPlayer(player);
+
+        if (nms.isSword(item))
+        {
+            event.getItem().setItemStack(arena.getTeam(player).handleItemEnchantment(item));
+        }
+
     }
 }


### PR DESCRIPTION
1.Fixed issue where swords do not gain sharpness in chest and enderchest.(Sword placed in a chest or enderchest before purchasing sharpness)
2.Fixed the issue where the wooden sword obtained after throwing a sword did not have sharpness.(The team has purchased Sharp)
3.Fixed the enchantment issue when picking up other players' swords.
4.Fixed the issue where axes were not receiving Sharpness enchantment.(Axes purchased before purchasing sharpness)