### PR TITLE
Default item related improvements

### DIFF
--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/Inventory.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/Inventory.java
@@ -141,9 +141,7 @@ public class Inventory implements Listener {
         }
 
         if (e.getCurrentItem() == null) return;
-        if (e.getCurrentItem().
-
-                getType() == Material.AIR) return;
+        if (e.getCurrentItem().getType() == Material.AIR) return;
 
         Player p = (Player) e.getWhoClicked();
         ItemStack i = e.getCurrentItem();

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/shop/listeners/InventoryListener.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/shop/listeners/InventoryListener.java
@@ -154,12 +154,10 @@ public class InventoryListener implements Listener {
             if (e.getCursor().getType() != Material.AIR) {
                 if (e.getClickedInventory() == null) {
                     if (shouldCancelMovement(e.getCursor(), sc)) {
-                        e.getWhoClicked().closeInventory();
                         e.setCancelled(true);
                     }
                 } else if (e.getClickedInventory().getType() != e.getWhoClicked().getInventory().getType()) {
                     if (shouldCancelMovement(e.getCursor(), sc)) {
-                        e.getWhoClicked().closeInventory();
                         e.setCancelled(true);
                     }
                 }


### PR DESCRIPTION
1. Prohibit discarding default swords (typically wooden swords).
2. When you obtain a higher-level sword, your wooden sword will be removed (new: take out the sword from the container).
3.Now, discarding wooden swords and other items will not close the player's inventory.