### PR TITLE
Fixed a bug where blocks below the team generator would be cleared during the Ender Dragon event.

### DIFF
--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/tasks/GamePlayingTask.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/tasks/GamePlayingTask.java
@@ -32,8 +32,6 @@ import com.andrei1058.bedwars.api.language.Messages;
 import com.andrei1058.bedwars.api.tasks.PlayingTask;
 import com.andrei1058.bedwars.arena.Arena;
 import org.bukkit.Bukkit;
-import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitTask;
@@ -142,14 +140,6 @@ public class GamePlayingTask implements Runnable, PlayingTask {
                         }
                     }
                     getArena().updateNextEvent();
-                    for (ITeam team : arena.getTeams()){
-                        for (IGenerator o : team.getGenerators()) {
-                            Location l = o.getLocation();
-                            for (int y = 0; y < 20; y++) {
-                                l.clone().subtract(0, y, 0).getBlock().setType(Material.AIR);
-                            }
-                        }
-                    }
                     for (ITeam t : getArena().getTeams()) {
                         if (t.getMembers().isEmpty()) continue;
                         for (int x = 0; x < t.getDragons(); x++) {


### PR DESCRIPTION
Bug description: During the progress of the Ender Dragon event in the game, the 20 blocks directly below the surviving team's generator will be cleared.

This behavior is incorrect, this PR deleted it.